### PR TITLE
Add test comparing with scipy, and fix to make it pass

### DIFF
--- a/src/pymultitaper/spectral.py
+++ b/src/pymultitaper/spectral.py
@@ -94,8 +94,8 @@ def _spectrogram(data:NDArray,fs:int,time_step:float,win:NDArray,weights:NDArray
     psd_data *= 2
     if fmin == 0:
         psd_data[:,0] /= 2
-    if fmax == fs/2 and nfft % 2 == 1:
-        # if nfft is odd, the Nyquist frequency is exactly at the middle of the spectrum and has no duplicate
+    if fmax == fs/2 and nfft % 2 == 0:
+        # if nfft is even, the Nyquist frequency is exactly at the middle of the spectrum and has no duplicate
         psd_data[:,-1] /= 2
     if db_scale:
         psd_data = 10*np.log10(psd_data/p_ref**2)

--- a/tests/test_compare_scipy.py
+++ b/tests/test_compare_scipy.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+from scipy import signal
+
+from pymultitaper import spectrogram
+
+
+@pytest.fixture(autouse=True)
+def deterministic_random(monkeypatch):
+    monkeypatch.setattr("numpy.random", np.random.RandomState(9876))
+
+
+@pytest.mark.parametrize("window_length_multiplier", [1, 5, 25])
+def test_compare_scipy(window_length_multiplier):
+    # white noise signal, 2s @8kHz
+    fs = 8000
+    x = np.linspace(0, 2, 2*fs)
+    data = np.random.normal(size=len(x))
+    # 10ms frame length
+    ts = 0.01
+    wl = ts * window_length_multiplier
+
+    st_times, st_freqs, st_spec = spectrogram(data,
+                                              fs=fs,
+                                              time_step=ts,
+                                              window_length=wl,
+                                              db_scale=False,
+                                              )
+    n_ts = int(ts * fs)
+    n_wl = int(wl * fs)
+    sc_freqs, sc_times, sc_spec = signal.spectrogram(data,
+                                                     fs=fs,
+                                                     nperseg=n_wl,
+                                                     nfft=2**int(np.ceil(np.log2(n_wl))),
+                                                     noverlap=n_wl - n_ts,
+                                                     window="hamming",
+                                                     )
+
+    assert st_freqs.shape == sc_freqs.shape
+    assert st_times.shape == sc_times.shape
+    assert st_spec.shape == st_spec.shape
+
+    assert np.allclose(st_times, sc_times - sc_times[0])
+    assert np.allclose(st_freqs, sc_freqs)
+    assert np.allclose(st_spec, sc_spec)


### PR DESCRIPTION
Ref issue #1:

As a first step:  add a test comparing the output of pymultitaper's `spectrogram` with the scipy one.

Also fixes a bug revealed by the test.